### PR TITLE
Added Dependencies Management System

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const { clio_import } = require('./internals/import');
 const beautify = require('js-beautify').js;
 const highlight = require('./highlight');
 const { get } = require('./internals/get/clio-get');
+const { showDependencies } = require('./internals/deps')
 
 global.fetch = require("node-fetch"); // fetch is not implemented in node (yet)
 global.WebSocket = require('websocket').w3cwebsocket; // same for WebSocket
@@ -146,6 +147,13 @@ const argv = require('yargs')
     })
   },
   (argv) => get(argv))
+  .command('deps.show', 'Shows the list of dependencies listed in Package.json', (yargs) => {
+    yargs.positional('source', {
+      describe: 'source file to analyze',
+      type: 'string'
+    })
+  },
+  (_) => showDependencies())
   .command('compile <source> <destination>', 'Compile a Clio file', (yargs) => {
     yargs.positional('source', {
       describe: 'source file to compile',

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const { clio_import } = require('./internals/import');
 const beautify = require('js-beautify').js;
 const highlight = require('./highlight');
 const { get } = require('./internals/get/clio-get');
-const { showDependencies } = require('./internals/deps')
+const { showDependencies, getDependencies } = require('./internals/deps')
 
 global.fetch = require("node-fetch"); // fetch is not implemented in node (yet)
 global.WebSocket = require('websocket').w3cwebsocket; // same for WebSocket
@@ -149,11 +149,18 @@ const argv = require('yargs')
   (argv) => get(argv))
   .command('deps.show', 'Shows the list of dependencies listed in Package.json', (yargs) => {
     yargs.positional('source', {
-      describe: 'source file to analyze',
+      describe: 'Shows the list of dependencies listed in Package.json',
       type: 'string'
     })
   },
   (_) => showDependencies())
+  .command('deps.get', 'Download every dependency listed in Package.json', (yargs) => {
+    yargs.positional('source', {
+      describe: 'Download every dependency listed in Package.json',
+      type: 'string'
+    })
+  },
+  (_) => getDependencies())
   .command('compile <source> <destination>', 'Compile a Clio file', (yargs) => {
     yargs.positional('source', {
       describe: 'source file to compile',

--- a/internals/deps/index.js
+++ b/internals/deps/index.js
@@ -1,0 +1,25 @@
+const { 
+        getClioDependencies
+      , hasClioDependencies 
+  } = require("../helpers/package");
+
+/**
+ * @method showDependencies
+ * @returns {void}
+ * @description Prints to the stdout the list of
+ *              dependencies listed in package.json
+ */
+function showDependencies() {
+  if (hasClioDependencies()) {
+    const deps = getClioDependencies();
+    const formattedDeps = deps.map((dep) => `~> ${dep}`)
+                              .join('\n');
+    console.log(formattedDeps);
+  } else {
+    console.log("No dependencies found in package.json");
+  }
+}
+
+module.exports = {
+  showDependencies
+}

--- a/internals/deps/index.js
+++ b/internals/deps/index.js
@@ -3,23 +3,47 @@ const {
       , hasClioDependencies 
   } = require("../helpers/package");
 
+const { get } = require('../get/clio-get')
+
 /**
  * @method showDependencies
  * @returns {void}
  * @description Prints to the stdout the list of
  *              dependencies listed in package.json
  */
+
 function showDependencies() {
-  if (hasClioDependencies()) {
-    const deps = getClioDependencies();
-    const formattedDeps = deps.map((dep) => `~> ${dep}`)
-                              .join('\n');
-    console.log(formattedDeps);
-  } else {
+  if (!hasClioDependencies()) { 
     console.log("No dependencies found in package.json");
+    return
+  }
+
+  const deps = getClioDependencies();
+  const formattedDeps = deps
+                          .map((dep) => `~> ${dep}`)
+                          .join('\n');
+  console.log(formattedDeps);
+}
+
+/**
+ * @method getDependencies
+ * @returns {void}
+ * @description Installs every dependency listed in
+ *              package.json
+ */
+
+function getDependencies() {
+  if (!hasClioDependencies()) {
+    console.log("No dependencies found in package.json");
+    return
+  }
+
+  for (const dep of getClioDependencies()) {
+    get({ url: dep })
   }
 }
 
 module.exports = {
-  showDependencies
+  showDependencies,
+  getDependencies
 }

--- a/internals/helpers/package.js
+++ b/internals/helpers/package.js
@@ -78,5 +78,6 @@ module.exports = {
   addDependency,
   getClioDependencies,
   hasClioDependencies,
-  updatePackageJsonDependencies
+  updatePackageJsonDependencies,
+  packageJson
 }


### PR DESCRIPTION
I've added the possibility to install and show dependencies listed in Package.json files under `clioDependencies` index.

Exmple:

```json
{
  "clioDependencies": [
	"foo",
	"bar",
	"github.com/foo/bar"
  ]
}
```
**List**
```sh
$ clio deps.show
# ~> foo
# ~> bar
# ~> github.com/foo/bar
```

**Install**
```sh
$ clio deps.get
# Downloading foo...
# Downloading bar...
# Downloading github.com/foo/bar...
```

Highly inspired to Elixir Hex