### PR TITLE
Cli new command

### DIFF
--- a/cli/createpackage.js
+++ b/cli/createpackage.js
@@ -6,44 +6,26 @@ function createPackage(packageName) {
   const cwd = process.cwd();
   const dir = path.join(cwd, packageName);
   fs.mkdir(dir, () => {
-    exec(`pushd ${packageName}` + ` && npm init -y` + ` && popd`, () => {
-      const pkg = require(path.join(dir, "package.json"));
-      if (!pkg.clioDependencies) {
-        pkg.clioDependencies = ["stdlib"];
-      } else if (!pkg.clioDependencies.includes("stdlib")) {
-        pkg.clioDependencies.push("stdlib");
-      }
-      const stringified = JSON.stringify(pkg, null, 2);
-      return fs.writeFile(
-        path.join(dir, "package.json"),
-        stringified,
-        "utf8",
-        err => {
-          if (err) {
-            console.error(err);
-          }
-          console.log("Added Clio dependency");
-        }
-      );
-    });
+    childProcess.execSync(
+      `pushd ${packageName}` + ` && npm init -y` + ` && popd`
+    );
+    console.log("Initialized npm module");
+
+    const pkg = require(path.join(dir, "package.json"));
+    if (!pkg.clioDependencies) {
+      pkg.clioDependencies = ["stdlib"];
+    } else if (!pkg.clioDependencies.includes("stdlib")) {
+      pkg.clioDependencies.push("stdlib");
+    }
+    const stringified = JSON.stringify(pkg, null, 2);
+    fs.writeFileSync(path.join(dir, "package.json"), stringified, "utf8");
+    console.log("Added Clio dependencies");
+
+    childProcess.execSync(
+      `pushd ${packageName}` +
+        ` && git init && git add -A && git commit -m "Initial Commit" && popd`
+    );
   });
 }
-
-const exec = (command, callback) => {
-  const process = childProcess.exec(command);
-
-  process.stdout.on("data", data => {
-    console.log(data.toString());
-  });
-
-  process.stderr.on("data", data => {
-    console.error(data.toString());
-  });
-
-  process.on("exit", code => {
-    console.log("npm module initialized");
-    callback();
-  });
-};
 
 module.exports = createPackage;

--- a/cli/createpackage.js
+++ b/cli/createpackage.js
@@ -1,31 +1,38 @@
 const fs = require("fs");
 const childProcess = require("child_process");
 const path = require("path");
+const shell = require("shelljs");
+const { getDependencies } = require("../internals/deps");
 
 function createPackage(packageName) {
+  if (!shell.which("git")) {
+    shell.echo("Sorry, this script requires git");
+    shell.exit(1);
+  }
   const cwd = process.cwd();
   const dir = path.join(cwd, packageName);
-  fs.mkdir(dir, () => {
-    childProcess.execSync(
-      `pushd ${packageName}` + ` && npm init -y` + ` && popd`
-    );
-    console.log("Initialized npm module");
 
-    const pkg = require(path.join(dir, "package.json"));
-    if (!pkg.clioDependencies) {
-      pkg.clioDependencies = ["stdlib"];
-    } else if (!pkg.clioDependencies.includes("stdlib")) {
-      pkg.clioDependencies.push("stdlib");
-    }
-    const stringified = JSON.stringify(pkg, null, 2);
-    fs.writeFileSync(path.join(dir, "package.json"), stringified, "utf8");
-    console.log("Added Clio dependencies");
+  shell.mkdir(packageName);
+  shell.cd(packageName);
+  shell.exec("npm init -y");
 
-    childProcess.execSync(
-      `pushd ${packageName}` +
-        ` && git init && git add -A && git commit -m "Initial Commit" && popd`
-    );
-  });
+  const pkg = require(path.join(dir, "package.json"));
+  if (!pkg.clioDependencies) {
+    pkg.clioDependencies = ["stdlib"];
+    delete pkg.main;
+    pkg.entry = "index.clio";
+    pkg.version = "0.1.0";
+    delete pkg.scripts;
+  } else if (!pkg.clioDependencies.includes("stdlib")) {
+    pkg.clioDependencies.push("stdlib");
+  }
+  const stringified = JSON.stringify(pkg, null, 2);
+  fs.writeFileSync(path.join(dir, "package.json"), stringified, "utf8");
+  console.log("Added Clio dependencies");
+
+  getDependencies();
+
+  shell.exec("git init && git add -A && git commit -m 'Initial Commit'");
 }
 
 module.exports = createPackage;

--- a/cli/createpackage.js
+++ b/cli/createpackage.js
@@ -28,11 +28,16 @@ function createPackage(packageName) {
   }
   const stringified = JSON.stringify(pkg, null, 2);
   fs.writeFileSync(path.join(dir, "package.json"), stringified, "utf8");
+  getDependencies();
   console.log("Added Clio dependencies");
 
-  getDependencies();
+  shell.exec(`echo "'Hello World' -> print" > index.clio`);
 
   shell.exec("git init && git add -A && git commit -m 'Initial Commit'");
+  shell.echo("\nInitialization Complete!");
+  shell.echo(
+    `Run 'cd ${packageName}' to open, then 'clio run index.clio' to run the project!`
+  );
 }
 
 module.exports = createPackage;

--- a/cli/createpackage.js
+++ b/cli/createpackage.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+const childProcess = require("child_process");
+const path = require("path");
+function createPackage(packageName) {
+  fs.mkdir(path.join(process.cwd(), packageName), () => {
+    exec(`pushd ${packageName}` + ` && npm init -y` + ` && popd`);
+  });
+}
+
+const exec = command => {
+  const process = childProcess.exec(command);
+
+  process.stdout.on("data", data => {
+    console.log(data.toString());
+  });
+
+  process.stderr.on("data", data => {
+    console.error(data.toString());
+  });
+
+  process.on("exit", code => {
+    console.log("Exited with code " + code.toString());
+  });
+};
+
+module.exports = createPackage;

--- a/cli/createpackage.js
+++ b/cli/createpackage.js
@@ -1,5 +1,4 @@
 const fs = require("fs");
-const childProcess = require("child_process");
 const path = require("path");
 const shell = require("shelljs");
 const { getDependencies } = require("../internals/deps");

--- a/cli/createpackage.js
+++ b/cli/createpackage.js
@@ -1,13 +1,35 @@
 const fs = require("fs");
 const childProcess = require("child_process");
 const path = require("path");
+
 function createPackage(packageName) {
-  fs.mkdir(path.join(process.cwd(), packageName), () => {
-    exec(`pushd ${packageName}` + ` && npm init -y` + ` && popd`);
+  const cwd = process.cwd();
+  const dir = path.join(cwd, packageName);
+  fs.mkdir(dir, () => {
+    exec(`pushd ${packageName}` + ` && npm init -y` + ` && popd`, () => {
+      const pkg = require(path.join(dir, "package.json"));
+      if (!pkg.clioDependencies) {
+        pkg.clioDependencies = ["stdlib"];
+      } else if (!pkg.clioDependencies.includes("stdlib")) {
+        pkg.clioDependencies.push("stdlib");
+      }
+      const stringified = JSON.stringify(pkg, null, 2);
+      return fs.writeFile(
+        path.join(dir, "package.json"),
+        stringified,
+        "utf8",
+        err => {
+          if (err) {
+            console.error(err);
+          }
+          console.log("Added Clio dependency");
+        }
+      );
+    });
   });
 }
 
-const exec = command => {
+const exec = (command, callback) => {
   const process = childProcess.exec(command);
 
   process.stdout.on("data", data => {
@@ -19,7 +41,8 @@ const exec = command => {
   });
 
   process.on("exit", code => {
-    console.log("Exited with code " + code.toString());
+    console.log("npm module initialized");
+    callback();
   });
 };
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+const createPackage = require("./cli/createpackage");
+
 global.fetch = require("node-fetch"); // fetch is not implemented in node (yet)
 global.WebSocket = require("websocket").w3cwebsocket; // same for WebSocket
 
@@ -42,7 +44,7 @@ async function process_file(argv) {
     );
   }
 
-  if (argv.command == "host") {    
+  if (argv.command == "host") {
     const path = require("path");
     const clio_host = require("./host/host");
     try {
@@ -53,7 +55,7 @@ async function process_file(argv) {
       var file_dir = path.dirname(file);
       global.__basedir = file_dir;
 
-      var _module = clio_import(argv.source);      
+      var _module = clio_import(argv.source);
     } catch (e) {
       return e.exit ? e.exit() : console.log(e);
     }
@@ -152,10 +154,23 @@ require("yargs")
   .command(
     "init",
     "Generate a package.json and fetch stdlib",
-    yargs => { },
+    yargs => {},
     argv => {
       const { initPackage } = require("./internals/helpers/pkginit");
       initPackage();
+    }
+  )
+  .command(
+    "new <project>",
+    "Create a new Clio project",
+    yargs => {
+      yargs.positional("project", {
+        describe: "name of the project",
+        type: "string"
+      });
+    },
+    argv => {
+      require("./cli/createpackage")(argv.project);
     }
   )
   .command(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1011,8 +1011,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -1189,7 +1188,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1919,8 +1917,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -3527,8 +3524,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.7",
@@ -4134,7 +4130,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4691,7 +4686,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4779,8 +4773,7 @@
     "interpret": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
-      "dev": true
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
     },
     "invariant": {
       "version": "2.2.4",
@@ -6399,7 +6392,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -7055,8 +7047,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -7072,8 +7063,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-platform": {
       "version": "0.11.15",
@@ -7538,7 +7528,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
       "requires": {
         "resolve": "^1.1.6"
       }
@@ -7732,7 +7721,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
       "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -8016,6 +8004,16 @@
         "array-map": "~0.0.0",
         "array-reduce": "~0.0.0",
         "jsonify": "~0.0.0"
+      }
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "shellwords": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "express-ws": "4.0.0",
     "js-beautify": "1.8.6",
     "node-fetch": "2.2.0",
+    "shelljs": "^0.8.3",
     "tmp": "0.0.33",
     "treeify": "1.1.0",
     "unescape-js": "1.1.0",


### PR DESCRIPTION
I've implemented a `clio new <projectname>` command that basically calls `pkginit()`, initializes a new git repo and adds a hello world call to `index.clio`. I tried to seperate the logic out to a new CLI folder. My suggestion would be to refactor the CLI to that folder, as it currently entirely lives in index.js. While doing that, we can also take care of the bloated yargs. Speaking of bloat: I added a new dependency (lol) to use a shell to make the initialization process easier, because i had some issues with the directory paths. What do you think?