### PR TITLE
Add gitignore to generated project

### DIFF
--- a/cli/commands/new.js
+++ b/cli/commands/new.js
@@ -46,6 +46,8 @@ function createPackage(packageName) {
 
   shell.exec(`echo "'Hello World' -> print" > index.clio`);
 
+  shell.exec(`echo ".clio-cache\nclio_env" > .gitignore`);
+
   shell.exec("git init && git add -A && git commit -m 'Initial Commit'");
   shell.echo("\nInitialization Complete!");
   shell.echo(


### PR DESCRIPTION
Fixes #42.

`node cli new test-project` yields:

<img width="187" alt="Screenshot 2019-12-17 at 15 49 51" src="https://user-images.githubusercontent.com/1965897/71011183-e3850780-20e4-11ea-8498-1caf50ecb9d6.png">

.gitignore content is:

```
.clio-cache
clio_env

```