### PR TITLE
Multiple authors clio.toml

### DIFF
--- a/cli/commands/new.js
+++ b/cli/commands/new.js
@@ -38,11 +38,7 @@ async function createPackage(packageName) {
       license: "ISC",
       main: "index.clio",
       keywords: "",
-      author: {
-        name: "",
-        email: "",
-        website: ""
-      },
+      authors: ["Your Name <you@example.com>"],
       scripts: { test: "No tests specified" },
       dependencies: [{ name: "stdlib", version: "latest" }]
     };
@@ -61,7 +57,9 @@ async function createPackage(packageName) {
     info("Initialized new git repository.");
 
     info("Initialization Complete!");
-    success(`Run 'cd ${packageName}' to open, then 'clio run index.clio' to run the project!`);
+    success(
+      `Run 'cd ${packageName}' to open, then 'clio run index.clio' to run the project!`
+    );
   } catch (e) {
     error(e);
     process.exit(1);

--- a/package/packageConfig.js
+++ b/package/packageConfig.js
@@ -18,11 +18,7 @@ function getPackageConfig(filepath = path.join(process.cwd(), configFileName)) {
     version: packageConfig.version,
     license: packageConfig.license,
     main: packageConfig.main,
-    author: {
-      name: packageConfig.author.name,
-      email: packageConfig.author.email,
-      website: packageConfig.author.website
-    },
+    authors: packageConfig.authors,
     keywords: packageConfig.keywords,
     // eslint-disable-next-line camelcase
     git_repository: packageConfig.git_repository,

--- a/tests/cli/init/new.test.js
+++ b/tests/cli/init/new.test.js
@@ -1,6 +1,8 @@
 const tmp = require("tmp");
 const fs = require("fs");
+const path = require("path");
 const { createPackage } = require("../../../cli/commands/new");
+const packageConfig = require("../../../package/packageConfig");
 
 test("Create a package", async () => {
   const dir = tmp.dirSync();
@@ -11,4 +13,13 @@ test("Create a package", async () => {
   expect(files.includes("clio_env")).toBe(true);
   expect(files.includes(".gitignore")).toBe(true);
   expect(files.includes(".git")).toBe(true);
+});
+
+test("Freshly generated project file includes multiple authors", async () => {
+  const dir = tmp.dirSync();
+  await createPackage(dir.name);
+  const config = packageConfig.getPackageConfig(
+    path.join(dir.name, "clio.toml")
+  );
+  expect(Array.isArray(config.authors)).toBe(true);
 });


### PR DESCRIPTION
We haven't fully discussed this feature yet. Wasn't much work, so I went ahead and implemented it in advance. 

In clio, as of now, only one author can be mentioned through multiple fields:

```toml
[author]
name = ""
email = ""
website = ""
```

In rust, it is possible to list multiple authors through a list:
```toml
[package]
name = "hello_cargo"
version = "0.1.0"
authors = ["Your Name <you@example.com>"]
edition = "2018"
```

I really like their approach. What do you think?