### PR TITLE
Add Inch documentation checker

### DIFF
--- a/inch.json
+++ b/inch.json
@@ -1,0 +1,6 @@
+{
+  "files": {
+    "included": ["**/*.js"],
+    "excluded": ["node_modules/"]
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 ![Travis (.org)](https://img.shields.io/travis/clio-lang/clio.svg)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fclio-lang%2Fclio.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fclio-lang%2Fclio?ref=badge_shield)
 [![Coverage Status](https://coveralls.io/repos/github/clio-lang/clio/badge.svg?branch=v0.2.0)](https://coveralls.io/github/clio-lang/clio?branch=v0.2.0)
+[![Inline docs](http://inch-ci.org/github/clio-lang/clio.svg?branch=itch-doc-lint)](http://inch-ci.org/github/clio-lang/clio)
 
 ![Clio Logo](https://raw.githubusercontent.com/clio-lang/media/master/logo-128x128.png)
 


### PR DESCRIPTION
I randomly checked out the `node-sass` repository and stumbled upon this documentation checker called [Inch](https://inch-ci.org/). It suggests, where our documentation could be improved.

We need a config file to have our code checked, but once we do, we get quite a nice breakdown:
https://inch-ci.org/github/clio-lang/clio?branch=itch-doc-lint

### ToDo:
- [x] Add Inch Webhook (documented [here](https://inch-ci.org/help/webhook))