### PR TITLE
Update Coveralls Badge branch

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 [![npm version](https://badge.fury.io/js/clio-lang.svg)](https://badge.fury.io/js/clio-lang)
 ![Travis (.org)](https://img.shields.io/travis/clio-lang/clio.svg)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fclio-lang%2Fclio.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fclio-lang%2Fclio?ref=badge_shield)
-[![Coverage Status](https://coveralls.io/repos/github/clio-lang/clio/badge.svg?branch=v0.2.0)](https://coveralls.io/github/clio-lang/clio?branch=v0.2.0)
+[![Coverage Status](https://coveralls.io/repos/github/clio-lang/clio/badge.svg?branch=develop)](https://coveralls.io/github/clio-lang/clio?branch=v0.2.0)
 [![Inline docs](http://inch-ci.org/github/clio-lang/clio.svg?branch=itch-doc-lint)](http://inch-ci.org/github/clio-lang/clio)
 [![Kanban Board](https://img.shields.io/badge/Kanban%20Board-v0.2.0-1abc9c.svg)](https://github.com/orgs/clio-lang/projects/1)
 


### PR DESCRIPTION
The coveralls badge in readme pointed to branch v0.2.0. I updated it to develop