### PR TITLE
Compile clio deps

### DIFF
--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -184,7 +184,6 @@ const build = async (
         const contents = await fs.promises.readFile(file, "utf8");
         const compiled = await generator(contents);
         const formatted = format(compiled, { parser: "babel" });
-        mkdir(destDir);
         await fs.promises.writeFile(destFile, formatted, "utf8");
       }
       progress.succeed();

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -159,21 +159,8 @@ const build = async (
       }
 
       const clioDepDirs = fs.readdirSync(path.join(source, ENV_NAME));
-
       for (const depDir of clioDepDirs) {
-        const configPath = path.join(source, ENV_NAME, depDir, CONFIGFILE_NAME);
-        const config = getPackageConfig(configPath);
-        const packageJson = {
-          main: config.main,
-          title: config.title
-        };
-        const destFilePath = path.join(
-          destination,
-          "node_modules",
-          path.basename(depDir),
-          "package.json"
-        );
-        fs.writeFileSync(destFilePath, JSON.stringify(packageJson));
+        buildPackageJson(source, depDir, destination);
       }
       progress.succeed();
     }
@@ -224,6 +211,27 @@ const build = async (
   } catch (e) {
     error(e, "Bundling");
   }
+};
+
+const buildPackageJson = (source, dependencyPath, destination) => {
+  const configPath = path.join(
+    source,
+    ENV_NAME,
+    dependencyPath,
+    CONFIGFILE_NAME
+  );
+  const config = getPackageConfig(configPath);
+  const packageJson = {
+    main: config.main,
+    title: config.title
+  };
+  const destFilePath = path.join(
+    destination,
+    "node_modules",
+    path.basename(dependencyPath),
+    "package.json"
+  );
+  fs.writeFileSync(destFilePath, JSON.stringify(packageJson));
 };
 
 const command = "build [target] [source] [destination]";

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -179,11 +179,11 @@ const build = async (
         const destFile = path
           .join(destination, `${relativeFile}.js`)
           .replace(ENV_NAME, "node_modules");
-        const destDir = path.dirname(destFile);
-        mkdir(destDir);
         const contents = await fs.promises.readFile(file, "utf8");
         const compiled = await generator(contents);
         const formatted = format(compiled, { parser: "babel" });
+        const destDir = path.dirname(destFile);
+        mkdir(destDir);
         await fs.promises.writeFile(destFile, formatted, "utf8");
       }
       progress.succeed();

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -8,7 +8,6 @@ const { Progress } = require("../lib/progress");
 
 const {
   CONFIGFILE_NAME,
-  SOURCE_NAME,
   ENV_NAME,
   fetchNpmDependencies,
   getPackageConfig,

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -68,7 +68,9 @@ function getBuildTarget(targetOverride, config) {
 
   const buildTarget =
     targetOverride ||
-    (buildConfig.target in config.target ? config.target[buildConfig.target].target : buildConfig.target);
+    (buildConfig.target in config.target
+      ? config.target[buildConfig.target].target
+      : buildConfig.target);
 
   if (!buildTarget) {
     throw new Error(
@@ -89,10 +91,14 @@ function getSourceFromConfig(source, target, config) {
   }
 
   const buildSource =
-    buildConfig.target in config.target ? config.target[buildConfig.target].directory : buildConfig.source;
+    buildConfig.target in config.target
+      ? config.target[buildConfig.target].directory
+      : buildConfig.source;
 
   if (!buildSource) {
-    throw new Error(`Could not find a source directory for ${target} in your ${CONFIGFILE_NAME} file.`);
+    throw new Error(
+      `Could not find a source directory for ${target} in your ${CONFIGFILE_NAME} file.`
+    );
   }
 
   return path.join(source, buildSource);
@@ -104,7 +110,11 @@ function getSourceFromConfig(source, target, config) {
  * @param {string} dest Destination directory to build.
  * @param {Object} options Options to build
  */
-const build = async (source, dest, { targetOverride, skipBundle, skipNpmInstall, silent } = {}) => {
+const build = async (
+  source,
+  dest,
+  { targetOverride, skipBundle, skipNpmInstall, silent } = {}
+) => {
   const config = getPackageConfig(path.join(source, CONFIGFILE_NAME));
   const target = getBuildTarget(targetOverride, config);
   const destination = dest || getDestinationFromConfig(source, target, config);
@@ -154,7 +164,10 @@ const build = async (source, dest, { targetOverride, skipBundle, skipNpmInstall,
         dependencies,
         main: "main.clio.js"
       };
-      fs.writeFileSync(packageJsonPath, JSON.stringify(packageJsonContent, null, 2));
+      fs.writeFileSync(
+        packageJsonPath,
+        JSON.stringify(packageJsonContent, null, 2)
+      );
     }
 
     if (!skipNpmInstall && !hasInstalledNpmDependencies(destination)) {

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -140,7 +140,7 @@ const build = async (
     }
     progress.succeed();
 
-    if (fs.existsSync(path.join(source, "clio_env"))) {
+    if (fs.existsSync(path.join(source, ENV_NAME))) {
       progress.start("Compiling Clio dependencies...");
       const files = getClioFiles(path.join(source, ENV_NAME));
       for (const file of files) {

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -128,8 +128,7 @@ const build = async (
   try {
     progress.start("Compiling source...");
 
-    // TODO: Source file should be taken from package config
-    const files = getClioFiles(path.join(source, SOURCE_NAME));
+    const files = getClioFiles(sourceDir);
     for (const file of files) {
       const relativeFile = path.relative(sourceDir, file);
       const destFile = path.join(destination, `${relativeFile}.js`);

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -127,6 +127,7 @@ const build = async (
   try {
     progress.start("Compiling source...");
 
+    // Build source
     const files = getClioFiles(sourceDir);
     for (const file of files) {
       const relativeFile = path.relative(sourceDir, file);
@@ -140,6 +141,7 @@ const build = async (
     }
     progress.succeed();
 
+    // Build clio deps
     if (fs.existsSync(path.join(source, ENV_NAME))) {
       progress.start("Compiling Clio dependencies...");
       const files = getClioFiles(path.join(source, ENV_NAME));
@@ -154,6 +156,24 @@ const build = async (
         const formatted = format(compiled, { parser: "babel" });
         mkdir(destDir);
         fs.writeFileSync(destFile, formatted, "utf8");
+      }
+
+      const clioDepDirs = fs.readdirSync(path.join(source, ENV_NAME));
+
+      for (const depDir of clioDepDirs) {
+        const configPath = path.join(source, ENV_NAME, depDir, CONFIGFILE_NAME);
+        const config = getPackageConfig(configPath);
+        const packageJson = {
+          main: config.main,
+          title: config.title
+        };
+        const destFilePath = path.join(
+          destination,
+          "node_modules",
+          path.basename(depDir),
+          "package.json"
+        );
+        fs.writeFileSync(destFilePath, JSON.stringify(packageJson));
       }
       progress.succeed();
     }

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -143,7 +143,7 @@ const build = async (
     progress.succeed();
 
     if (fs.existsSync(path.join(source, "clio_env"))) {
-      progress.start("Compiling Clio Dependencies...");
+      progress.start("Compiling Clio dependencies...");
       const files = getClioFiles(path.join(source, ENV_NAME));
       for (const file of files) {
         const relativeFile = path.relative(sourceDir, file);

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -144,8 +144,10 @@ const build = async (
       progress.start("Compiling Clio dependencies...");
       const files = getClioFiles(path.join(source, ENV_NAME));
       for (const file of files) {
-        const relativeFile = path.relative(sourceDir, file);
-        const destFile = path.join(destination, `${relativeFile}.js`);
+        const relativeFile = path.relative(source, file);
+        const destFile = path
+          .join(destination, `${relativeFile}.js`)
+          .replace(ENV_NAME, "node_modules");
         const destDir = path.dirname(destFile);
         const contents = fs.readFileSync(file, "utf8");
         const compiled = await generator(contents);

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -158,6 +158,7 @@ const build = async (
         fs.writeFileSync(destFile, formatted, "utf8");
       }
 
+      // Build package.json files
       const clioDepDirs = fs.readdirSync(path.join(source, ENV_NAME));
       for (const depDir of clioDepDirs) {
         buildPackageJson(source, depDir, destination);
@@ -213,13 +214,16 @@ const build = async (
   }
 };
 
-const buildPackageJson = (source, dependencyPath, destination) => {
-  const configPath = path.join(
-    source,
-    ENV_NAME,
-    dependencyPath,
-    CONFIGFILE_NAME
-  );
+/**
+ * Generates a package.json for a clio module.
+ * Reads the configuration file of the module and builds a package.json file containing all nessessary fields
+ *
+ * @param {string} source source root directory of clio project
+ * @param {string} dependency name of the dependency being compiled
+ * @param {string} destination destination for package.json
+ */
+const buildPackageJson = (source, dependency, destination) => {
+  const configPath = path.join(source, ENV_NAME, dependency, CONFIGFILE_NAME);
   const config = getPackageConfig(configPath);
   const packageJson = {
     main: config.main,
@@ -228,7 +232,7 @@ const buildPackageJson = (source, dependencyPath, destination) => {
   const destFilePath = path.join(
     destination,
     "node_modules",
-    path.basename(dependencyPath),
+    path.basename(dependency),
     "package.json"
   );
   fs.writeFileSync(destFilePath, JSON.stringify(packageJson));

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -157,8 +157,10 @@ const build = async (
         mkdir(destDir);
         fs.writeFileSync(destFile, formatted, "utf8");
       }
+      progress.succeed();
 
       // Build package.json files
+      progress.start("Linking Clio dependencies...");
       const clioDepDirs = fs.readdirSync(path.join(source, ENV_NAME));
       for (const depDir of clioDepDirs) {
         buildPackageJson(source, depDir, destination);

--- a/cli/commands/tests/run.test.js
+++ b/cli/commands/tests/run.test.js
@@ -1,24 +1,11 @@
-/*
------------------------------
-Disabling this for now
-I haven't updated the run
-command yet
------------------------------
 const tmp = require("tmp");
-const path = require('path');
 const { createPackage } = require('../../../cli/commands/new');
 const { run } = require('../../../cli/commands/run');
 
 test("Runs hello world", async () => {
   console.log = jest.fn();
   const dir = tmp.dirSync();
-  await createPackage(dir.name, true);
-  const source = path.join(dir.name, 'index.clio');
-  await run(source);
+  await createPackage(dir.name);
+  await run(dir.name);
   expect(console.log).toBeCalledWith('Hello World');
-});
-*/
-
-test("Runs hello world", async () => {
-  expect(true).toEqual(true);
 });

--- a/cli/commands/tests/run.test.js
+++ b/cli/commands/tests/run.test.js
@@ -16,7 +16,6 @@ test("Runs hello world", async () => {
 });
 
 test("Runs a project with dependencies", async () => {
-  console.log = jest.fn();
   const dir = tmp.dirSync();
   await createPackage(dir.name);
   const config = packageConfig.getPackageConfig(

--- a/cli/commands/tests/run.test.js
+++ b/cli/commands/tests/run.test.js
@@ -7,5 +7,5 @@ test("Runs hello world", async () => {
   const dir = tmp.dirSync();
   await createPackage(dir.name);
   await run(dir.name);
-  expect(console.log).toBeCalledWith('Hello World');
+  expect(console.log).toHaveBeenCalledWith('Hello World');
 });

--- a/cli/commands/tests/run.test.js
+++ b/cli/commands/tests/run.test.js
@@ -1,11 +1,30 @@
 const tmp = require("tmp");
-const { createPackage } = require('../../../cli/commands/new');
-const { run } = require('../../../cli/commands/run');
+const path = require("path");
+const { createPackage } = require("../../../cli/commands/new");
+const { run } = require("../../../cli/commands/run");
+const deps = require("../../../cli/commands/deps_commands/get");
+const packageConfig = require("../../../package/packageConfig");
 
 test("Runs hello world", async () => {
   console.log = jest.fn();
   const dir = tmp.dirSync();
   await createPackage(dir.name);
   await run(dir.name);
-  expect(console.log).toHaveBeenCalledWith('Hello World');
+  dir.removeCallback();
+  expect(console.log).toHaveBeenCalledWith("Hello World");
+});
+
+test("Runs a project with dependencies", async () => {
+  console.log = jest.fn();
+  const dir = tmp.dirSync();
+  await createPackage(dir.name);
+  const config = packageConfig.getPackageConfig(
+    path.join(dir.name, "clio.toml")
+  );
+  config.dependencies.push({ name: "hub:add", version: "latest" });
+  packageConfig.writePackageConfig(config, dir.name);
+  await deps.handler();
+  await run(dir.name);
+  await dir.removeCallback();
+  expect(console.log).toHaveBeenCalled();
 });

--- a/cli/commands/tests/run.test.js
+++ b/cli/commands/tests/run.test.js
@@ -1,5 +1,6 @@
 const tmp = require("tmp");
 const path = require("path");
+const fs = require("fs");
 const { createPackage } = require("../../../cli/commands/new");
 const { run } = require("../../../cli/commands/run");
 const deps = require("../../../cli/commands/deps_commands/get");
@@ -25,6 +26,10 @@ test("Runs a project with dependencies", async () => {
   packageConfig.writePackageConfig(config, dir.name);
   await deps.handler();
   await run(dir.name);
+  expect(
+    fs
+      .readdirSync(path.join(dir.name, "build", "node", "node_modules"))
+      .toString()
+  ).toContain("add");
   await dir.removeCallback();
-  expect(console.log).toHaveBeenCalled();
 });

--- a/package/config.js
+++ b/package/config.js
@@ -1,6 +1,7 @@
 module.exports = {
   CONFIGFILE_NAME: "clio.toml",
   ENV_NAME: "clio_env",
+  SOURCE_NAME: "src",
   GITHUB_PREFIX: "github",
   REGISTRY_NAME: "hub",
   URL_PREFIX: "url"


### PR DESCRIPTION
Closes #124 

This PR aims to compile packages located in `clio_env/` into the `node_modules/` directory, so that they can be imported from clio files

### ToDo
- [x] Create package.json for compiled clio modules
- [x] Add tests
- [x] Add documentation (https://github.com/clio-lang/clio-docs/pull/6)
- [x] FIXME: `clio run`/`clio build` needs to run twice