### PR TITLE
Move jest configuration to jest.config.js

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  collectCoverageFrom: [
+    "**/*.js",
+    "!**/*.clio.js",
+    "!coverage/**/*.js",
+    "!index.js",
+    "!browser.js",
+    "!common.js",
+    "!gulpfile.js",
+    "!highlight.js",
+    "!jest-puppeteer.config.js",
+    "!host/**/*",
+    "!tests/**/*"
+  ],
+  moduleFileExtensions: ["js", "json", "jsx", "ts", "tsx", "node", "toml"],
+  testEnvironment: "node"
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
     "**/*.js",
     "!**/*.clio.js",
     "!coverage/**/*.js",
+    "!jest.config.js",
     "!index.js",
     "!browser.js",
     "!common.js",

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
     "!host/**/*",
     "!tests/**/*"
   ],
+  testPathIgnorePatterns: ["<rootDir>/jest.config.js"],
   moduleFileExtensions: ["js", "json", "jsx", "ts", "tsx", "node", "toml"],
   testEnvironment: "node"
 };

--- a/package.json
+++ b/package.json
@@ -34,31 +34,6 @@
     "type": "git",
     "url": "https://github.com/clio-lang/clio.git"
   },
-  "jest": {
-    "collectCoverageFrom": [
-      "**/*.js",
-      "!**/*.clio.js",
-      "!coverage/**/*.js",
-      "!index.js",
-      "!browser.js",
-      "!common.js",
-      "!gulpfile.js",
-      "!highlight.js",
-      "!jest-puppeteer.config.js",
-      "!host/**/*",
-      "!tests/**/*"
-    ],
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "jsx",
-      "ts",
-      "tsx",
-      "node",
-      "toml"
-    ],
-    "testEnvironment": "node"
-  },
   "dependencies": {
     "@iarna/toml": "^2.2.3",
     "bean-parser": "^1.0.8",


### PR DESCRIPTION
Fixes None

### Description
Moved Jest config to it's own file, as documented [here](https://jestjs.io/docs/en/configuration)

### Changes proposed in this pull request

- Remove jest configuration `from package.json`
- Add `jest.config.js`

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
  - If theres a related PR in our [docs repository](https://github.com/clio-lang/clio-docs), attach it here: ...
