### PR TITLE
Fix "Error: undefined" message

### DIFF
--- a/cli/lib/colors.js
+++ b/cli/lib/colors.js
@@ -7,7 +7,7 @@ exports.brightRed = brightRed;
 exports.trace = e => console.trace(brightRed(`Error: ${e.message}`));
 
 exports.error = (e, prefix = "") => {
-  let message = `Error: ${e.message}`;
+  let message = `Error: ${e.message || e}`;
   if (prefix) message = `${prefix} `.concat(message);
   console.error(brightRed(message));
   process.exit(4);

--- a/cli/lib/tests/colors.test.js
+++ b/cli/lib/tests/colors.test.js
@@ -53,6 +53,13 @@ describe("Colored messages", () => {
     expect(process.exit).toHaveBeenCalled();
   });
 
+  test("error with string", () => {
+    const err = "err";
+    error(err);
+
+    expect(console.error).toHaveBeenCalledWith(brightRed("Error: err"));
+  });
+
   test("warn", () => {
     warn("Hey, be careful.");
 

--- a/packages/internals/src/scope.js
+++ b/packages/internals/src/scope.js
@@ -20,7 +20,7 @@ class Scope {
     } else if (this.outerScope) {
       return this.outerScope.get(key);
     } else {
-      throw new Error("Not defined");
+      throw new Error(`Error! ${key} is undefined!`);
     }
   }
   set(key, value) {

--- a/packages/internals/src/scope.js
+++ b/packages/internals/src/scope.js
@@ -20,7 +20,7 @@ class Scope {
     } else if (this.outerScope) {
       return this.outerScope.get(key);
     } else {
-      throw new Error(`Error! ${key} is undefined!`);
+      throw new Error(`${key} is not defined`);
     }
   }
   set(key, value) {

--- a/packages/internals/src/scope.js
+++ b/packages/internals/src/scope.js
@@ -20,7 +20,7 @@ class Scope {
     } else if (this.outerScope) {
       return this.outerScope.get(key);
     } else {
-      throw "Not defined";
+      throw new Error("Not defined");
     }
   }
   set(key, value) {


### PR DESCRIPTION
Fixes None

### Description

The compiler currently oftentimes throws a useless error. I found the issue when roaming through the code, so I fixed it. The error that is thrown at this point need to be more concrete, which we should fix soon.

### Changes proposed in this pull request

- In case a `string` is thrown instead of an `Error`, the string will be printed
- The error that caused the `Error: undefined` message now is a proper `Error` object

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
  - If theres a related PR in our [docs repository](https://github.com/clio-lang/clio-docs), attach it here: ...
