### PR TITLE
[WIP] Link local internals on build

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -5,3 +5,5 @@ Here we post developer resources.
 - [Project structure](file-structure)
 
 - [Dependency parser](./dependency_parser)
+
+- [Configuration](./configuration)

--- a/docs/dev/configuration/README.md
+++ b/docs/dev/configuration/README.md
@@ -1,0 +1,5 @@
+# Configuration
+
+## The `CLIOENV` variable
+
+If the `CLIOENV` variable is set, Clio will skip the installation of the `clio-internals` package during the build process, and instead copy the local source code to the location of the `clio-internals` package (Refer to [#146](https://github.com/clio-lang/clio/pull/146)).

--- a/docs/install.md
+++ b/docs/install.md
@@ -38,3 +38,9 @@ Now you need to install dependencies, to do that run:
 Now you need to link the `clio` executable:
 
 `npm run link`
+
+If you are planning to make changes to the local clio installation, you will need to specify its location in the `CLIOPATH` environment variable. This ensures, that local clio packages will be used when building a project. Add this line to your `.bashrc` file:
+
+```
+export CLIOPATH=<path-to-clio-installation>
+```

--- a/packages/cli/commands/build.js
+++ b/packages/cli/commands/build.js
@@ -26,6 +26,23 @@ const isClioFile = file => file.endsWith(".clio");
 const isNotClioFile = file => !file.endsWith(".clio");
 const getClioFiles = dir => walk(dir).filter(isClioFile);
 const getNonClioFiles = dir => walk(dir).filter(isNotClioFile);
+const copyDir = async (src, dest) => {
+  const entries = await fs.promises.readdir(src, { withFileTypes: true });
+  mkdir(dest);
+  for (let entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      await copyDir(srcPath, destPath);
+    } else {
+      await fs.promises.copyFile(
+        srcPath,
+        destPath,
+        fs.constants.COPYFILE_FICLONE
+      );
+    }
+  }
+};
 
 const mkdir = directory => {
   const { root, dir, base } = path.parse(directory);

--- a/packages/cli/commands/build.js
+++ b/packages/cli/commands/build.js
@@ -334,5 +334,6 @@ module.exports = {
   builder,
   handler,
   getBuildTarget,
-  getDestinationFromConfig
+  getDestinationFromConfig,
+  copyDir
 };

--- a/packages/cli/commands/tests/build.test.js
+++ b/packages/cli/commands/tests/build.test.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const tmp = require("tmp");
 const { build, _new } = require("../");
+const { copyDir } = require("../build");
 const { CONFIGFILE_NAME } = require("clio-manifest");
 
 jest.mock("clio-manifest/npm_dependencies");
@@ -153,5 +154,33 @@ target = "alternative"`
     const files = fs.readdirSync(path.join(dir.name, "another-path"));
     expect(files.includes("main.clio.js")).toBe(true);
     dir.removeCallback();
+  });
+});
+
+describe("copyDir", () => {
+  test("copyDir to a new directory", async () => {
+    const tempSource = tmp.dirSync();
+
+    fs.writeFileSync(path.join(tempSource.name, "test"), "foo");
+    await copyDir(tempSource.name, path.join(tempSource.name, "out"));
+    expect(
+      await fs.promises.readdir(path.join(tempSource.name, "out").toString())
+    ).toEqual(["test"]);
+
+    tempSource.removeCallback();
+  });
+
+  test("copyDir to an existing directory", async () => {
+    const tempSource = tmp.dirSync();
+    const tempTarget = tmp.dirSync();
+
+    fs.writeFileSync(path.join(tempSource.name, "test"), "foo");
+    await copyDir(tempSource.name, tempTarget.name);
+    expect(
+      await fs.promises.readdir(path.join(tempTarget.name).toString())
+    ).toEqual(["test"]);
+
+    tempSource.removeCallback();
+    tempTarget.removeCallback();
   });
 });


### PR DESCRIPTION
Fixes #114 

### Description
This PR introduces a way to link the local internals package to the project on compilation. This eliminates the need to have remote internals as a dependency, which can get out of sync.

This might be a weird workaround until we have moved all our logic into their own packages, as lerna cannot link packages to directories that live in the project root. Once we have moved all modules to their own packages, we can use lerna to link the local internals package.

### Changes proposed in this pull request

- Source of local internals package is copied to project dependencies on compiletime

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
- [x] dependencies to remote package are completely eliminated
