### PR TITLE
Replace gitter with telegram

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 [![npm version](https://badge.fury.io/js/clio-lang.svg)](https://badge.fury.io/js/clio-lang)
-[![Gitter](https://badges.gitter.im/clio-lang/community.svg)](https://gitter.im/clio-lang/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Telegram](https://img.shields.io/badge/Telegram-Chat-blue)](https://t.me/joinchat/K2tN9kkVldcinF4U08lcfQ)
 ![Travis (.org)](https://img.shields.io/travis/clio-lang/clio.svg)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fclio-lang%2Fclio.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fclio-lang%2Fclio?ref=badge_shield)
 [![Coverage Status](https://coveralls.io/repos/github/clio-lang/clio/badge.svg?branch=develop)](https://coveralls.io/github/clio-lang/clio?branch=develop)
@@ -48,7 +48,7 @@ test programs exist, it is not recommended to use in production.
 - [Documentation](http://docs.clio-lang.org)
 - [Clio on Rosetta Code](http://rosettacode.org/wiki/Clio)
 - [Web IDE](https://clio-lang.github.io/clio-editor/)
-- [Clio Chat (on Gitter)](https://gitter.im/clio-lang/community?utm_source=share-link&utm_medium=link&utm_campaign=share-link)
+- [Clio Telegram Chat](https://t.me/joinchat/K2tN9kkVldcinF4U08lcfQ)
 - [Kanban Board](https://github.com/orgs/clio-lang/projects/1)
 
 ## Examples
@@ -97,5 +97,7 @@ Thank you to all the people who already contributed to Clio!
 </a>
 
 ## License
+
+Apache-2.0
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fclio-lang%2Fclio.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fclio-lang%2Fclio?ref=badge_large)


### PR DESCRIPTION
### Description

We don't use gitter anymore, so we should replace the links with telegram

### Changes proposed in this pull request

- Update links to telegram
- Add telegram badge

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
