### PR TITLE
Override package.json on build

### DIFF
--- a/packages/cli/commands/build.js
+++ b/packages/cli/commands/build.js
@@ -161,20 +161,19 @@ const build = async (
     // Init npm modules
     try {
       const packageJsonPath = path.join(destination, "package.json");
-      if (!fs.existsSync(packageJsonPath)) {
-        const dependencies = getParsedNpmDependencies(source);
-        dependencies["clio-internals"] = "latest";
-        const packageJsonContent = {
-          dependencies,
-          main: "main.clio.js"
-        };
-        fs.writeFileSync(
-          packageJsonPath,
-          JSON.stringify(packageJsonContent, null, 2)
-        );
-      }
+      const dependencies = getParsedNpmDependencies(source);
+      dependencies["clio-internals"] = "latest";
+      const packageJsonContent = {
+        dependencies,
+        main: "main.clio.js"
+      };
+      fs.writeFileSync(
+        packageJsonPath,
+        JSON.stringify(packageJsonContent, null, 2),
+        { flag: "w" }
+      );
 
-      if (!skipNpmInstall && !hasInstalledNpmDependencies(destination)) {
+      if (!skipNpmInstall) {
         progress.start(
           "Installing npm dependencies (this may take a while)..."
         );


### PR DESCRIPTION
Fixes #158

### Description

Fixes a bug where new dependencies were not added to package.json files in the build directory. Therefore, the user was forced to delete the build directory after adding a new dependency

### Changes proposed in this pull request

- Remove check, if package.json file exists
- Force override of package.json file using `"w"` flag

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
