### PR TITLE
Fix function parsing

### DIFF
--- a/packages/internals/src/functions.js
+++ b/packages/internals/src/functions.js
@@ -71,6 +71,8 @@ const fn = (...args) => new Fn(...args);
 
 module.exports.fn = fn;
 module.exports.Fn = Fn;
+module.exports.getArity = getArity;
+module.exports.ExtensibleFunction = ExtensibleFunction;
 
 const uuidv4 = require("./uuidv4");
 const { Scope } = require("./scope");

--- a/packages/internals/src/functions.js
+++ b/packages/internals/src/functions.js
@@ -6,8 +6,15 @@ const tryOr = (fn, or) => {
   }
 };
 
-const getParameters = fn =>
-  acorn.parse(fn.toString()).body[0].expression.params;
+const getParameters = fn => {
+  const { body } = acorn.parse(fn.toString());
+  if (body[0].type == "ExpressionStatement") {
+    return body[0].expression.params;
+  } else if (body[0].type == "FunctionDeclaration") {
+    return body[0].params;
+  }
+  throw "Function has an unknown body";
+};
 
 const getArity = fn => {
   const params = tryOr(() => getParameters(fn), []);

--- a/packages/internals/tests/functions.test.js
+++ b/packages/internals/tests/functions.test.js
@@ -1,4 +1,4 @@
-const { Fn } = require("../src/functions");
+const { Fn, getArity } = require("../src/functions");
 const { Lazy } = require("../src/lazy");
 
 test("Test Clio function currying", () => {
@@ -6,4 +6,26 @@ test("Test Clio function currying", () => {
   const add2 = add(2);
   expect(add2).toBeInstanceOf(Fn);
   expect(add2(3).valueOf()).toBe(5);
+});
+
+test("Test getArity", () => {
+  const arity = getArity(function(a, b, c) {
+    return a + b + c;
+  });
+  expect(arity).toBe(3);
+});
+
+test("Test getArity on fat arrow functions", () => {
+  const arity = getArity((a, b, c) => a + b + c);
+  expect(arity).toBe(3);
+});
+
+test("Test getArity with default values", () => {
+  const arity = getArity((a, b = 2, c) => a + b + c);
+  expect(arity).toBe(3);
+});
+
+test("Test getArity with rest operator", () => {
+  const arity = getArity((a, b, ...rest) => [a, b, ...rest]);
+  expect(arity).toBe(Infinity);
 });

--- a/packages/internals/tests/functions.test.js
+++ b/packages/internals/tests/functions.test.js
@@ -15,6 +15,13 @@ test("Test getArity", () => {
   expect(arity).toBe(3);
 });
 
+test("Test getArity with function declaration", () => {
+  const arity = getArity(function myFunction(a, b, c) {
+    return a + b + c;
+  });
+  expect(arity).toBe(3);
+});
+
 test("Test getArity on fat arrow functions", () => {
   const arity = getArity((a, b, c) => a + b + c);
   expect(arity).toBe(3);


### PR DESCRIPTION
Fixes a bug in `getArity` function

### Description

Apparently `acorn` returns different body results depending on how a function is defined.

### Changes proposed in this pull request

- Check body type of `acorn` parse results.

### ToDo

- [X] Proposed feature/fix is sufficiently tested
- [X] Proposed feature/fix is sufficiently documented
