### PR TITLE
Remove acorn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4559,7 +4559,8 @@
     "acorn": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "dev": true
     },
     "acorn-globals": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "@iarna/toml": "^2.2.3",
     "bean-parser": "^1.0.9",
-    "acorn": "^7.1.0",
     "chalk": "3.0.0",
     "decompress": "4.2.0",
     "node-fetch": "2.6.0",

--- a/packages/internals/package-lock.json
+++ b/packages/internals/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "clio-internals",
+  "version": "0.1.0",
+  "lockfileVersion": 1
+}

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -8,7 +8,5 @@
   },
   "author": "Andrey Luiz <andreyluiz.developer@gmail.com>",
   "license": "Apache-2.0",
-  "dependencies": {
-    "acorn": "^7.1.0"
-  }
+  "dependencies": {}
 }

--- a/packages/internals/src/arity.js
+++ b/packages/internals/src/arity.js
@@ -1,0 +1,47 @@
+const toString = Object.prototype.toString;
+const fnToString = Function.prototype.toString;
+const reHostCtor = /^\[object .+?Constructor\]$/;
+const reNative = RegExp(
+  "^" +
+    String(toString)
+      .replace(/[.*+?^${}()|[\]\/\\]/g, "\\$&")
+      .replace(/toString|(function).*?(?=\\\()| for .+?(?=\\\])/g, "$1.*?") +
+    "$"
+);
+
+const isNative = fn => {
+  const type = typeof fn;
+  return type == "function"
+    ? reNative.test(fnToString.call(fn))
+    : (fn && type == "object" && reHostCtor.test(toString.call(fn))) || false;
+};
+
+const getParenEnd = source => {
+  let i = 0,
+    lpar = 0,
+    rpar = 0;
+  while (i < source.length - 1) {
+    if (source[i] == "{" && lpar == rpar) return i;
+    if (source[i] == ">" && source[i - 1] == "=" && lpar == rpar) return i - 1;
+    if (source[i] == "(") lpar++;
+    if (source[i] == ")") rpar++;
+    i++;
+  }
+};
+
+const getArity = fn => {
+  const source = fn.toString();
+  if (isNative(fn)) return fn.length;
+  const end = getParenEnd(source);
+  let paramText = source.slice(0, end);
+  paramText = paramText.replace(/^[^(]*?\(/, "").replace(/\) *$/, "");
+  paramText = paramText.replace(/('|")([^\\]|\\.)*?\1/, "");
+  paramText = paramText.replace(/(\(([^(]+|\2)+\))/, "");
+  paramText = paramText.replace(/(\[([^[]+|\2)+\])/, "");
+  paramText = paramText.replace(/({([^{]+|\2)+})/, "");
+  paramText = paramText.replace(/[^,.]/gi, "");
+  if (paramText.includes("...")) return Infinity;
+  return paramText.length + 1;
+};
+
+module.exports.getArity = getArity;

--- a/packages/internals/src/arity.js
+++ b/packages/internals/src/arity.js
@@ -35,10 +35,10 @@ const getArity = fn => {
   const end = getParenEnd(source);
   let paramText = source.slice(0, end);
   paramText = paramText.replace(/^[^(]*?\(/, "").replace(/\) *$/, "");
-  paramText = paramText.replace(/('|")([^\\]|\\.)*?\1/, "");
-  paramText = paramText.replace(/(\(([^(]+|\1)+\))/, "");
-  paramText = paramText.replace(/(\[([^[]+|\1)+\])/, "");
-  paramText = paramText.replace(/({([^{]+|\1)+})/, "");
+  paramText = paramText.replace(/(['"])([^\\]|\\.)*?\1/g, "");
+  while (paramText != (paramText = paramText.replace(/\[[^\[\]]+\]/g, "")));
+  while (paramText != (paramText = paramText.replace(/\([^())]+\)/g, "")));
+  while (paramText != (paramText = paramText.replace(/{[^{}}]+}/g, "")));
   paramText = paramText.replace(/[^,.]/gi, "");
   if (paramText.includes("...")) return Infinity;
   return paramText.length + 1;

--- a/packages/internals/src/arity.js
+++ b/packages/internals/src/arity.js
@@ -37,8 +37,8 @@ const getArity = fn => {
   paramText = paramText.replace(/^[^(]*?\(/, "").replace(/\) *$/, "");
   paramText = paramText.replace(/(['"])([^\\]|\\.)*?\1/g, "");
   while (paramText != (paramText = paramText.replace(/\[[^\[\]]+\]/g, "")));
-  while (paramText != (paramText = paramText.replace(/\([^())]+\)/g, "")));
-  while (paramText != (paramText = paramText.replace(/{[^{}}]+}/g, "")));
+  while (paramText != (paramText = paramText.replace(/\([^()]+\)/g, "")));
+  while (paramText != (paramText = paramText.replace(/{[^{}]+}/g, "")));
   paramText = paramText.replace(/[^,.]/gi, "");
   if (paramText.includes("...")) return Infinity;
   return paramText.length + 1;

--- a/packages/internals/src/arity.js
+++ b/packages/internals/src/arity.js
@@ -36,9 +36,9 @@ const getArity = fn => {
   let paramText = source.slice(0, end);
   paramText = paramText.replace(/^[^(]*?\(/, "").replace(/\) *$/, "");
   paramText = paramText.replace(/('|")([^\\]|\\.)*?\1/, "");
-  paramText = paramText.replace(/(\(([^(]+|\2)+\))/, "");
-  paramText = paramText.replace(/(\[([^[]+|\2)+\])/, "");
-  paramText = paramText.replace(/({([^{]+|\2)+})/, "");
+  paramText = paramText.replace(/(\(([^(]+|\1)+\))/, "");
+  paramText = paramText.replace(/(\[([^[]+|\1)+\])/, "");
+  paramText = paramText.replace(/({([^{]+|\1)+})/, "");
   paramText = paramText.replace(/[^,.]/gi, "");
   if (paramText.includes("...")) return Infinity;
   return paramText.length + 1;

--- a/packages/internals/src/functions.js
+++ b/packages/internals/src/functions.js
@@ -1,28 +1,3 @@
-const tryOr = (fn, or) => {
-  try {
-    return fn();
-  } catch (error) {
-    return or;
-  }
-};
-
-const getParameters = fn => {
-  const { body } = acorn.parse(fn.toString());
-  if (body[0].type == "ExpressionStatement") {
-    return body[0].expression.params;
-  } else if (body[0].type == "FunctionDeclaration") {
-    return body[0].params;
-  }
-  throw "Function has an unknown body";
-};
-
-const getArity = fn => {
-  const params = tryOr(() => getParameters(fn), []);
-  const last = params.pop();
-  if (last && last.type == "RestElement") return Infinity;
-  return Math.max(fn.length, params.length + (last ? 1 : 0));
-};
-
 class ExtensibleFunction extends Function {
   constructor(fn) {
     super();
@@ -71,11 +46,10 @@ const fn = (...args) => new Fn(...args);
 
 module.exports.fn = fn;
 module.exports.Fn = Fn;
-module.exports.getArity = getArity;
 module.exports.ExtensibleFunction = ExtensibleFunction;
 
 const uuidv4 = require("./uuidv4");
 const { Scope } = require("./scope");
 const { IO } = require("./io");
 const { Lazy } = require("./lazy");
-const acorn = require("acorn");
+const { getArity } = require("./arity");

--- a/packages/internals/tests/functions.test.js
+++ b/packages/internals/tests/functions.test.js
@@ -1,4 +1,5 @@
-const { Fn, getArity } = require("../src/functions");
+const { Fn } = require("../src/functions");
+const { getArity } = require("../src/arity");
 const { Lazy } = require("../src/lazy");
 
 test("Test Clio function currying", () => {
@@ -35,4 +36,29 @@ test("Test getArity with default values", () => {
 test("Test getArity with rest operator", () => {
   const arity = getArity((a, b, ...rest) => [a, b, ...rest]);
   expect(arity).toBe(Infinity);
+});
+
+test("Test getArity with deconstructing parameters", () => {
+  const airty = getArity((a, { x, y, z }, c = [1, 2, 3]) => {});
+  expect(arity).toBe(3);
+});
+
+test("Test getArity with array and object as default values", () => {
+  const airty = getArity((a, c = [1, 2, 3], i = { x, y, z }) => {});
+  expect(arity).toBe(3);
+});
+
+test("Test getArity with string and parentheses default values", () => {
+  const airty = getArity((a, c = ",", b = 2 && (3 || 4)) => {});
+  expect(arity).toBe(3);
+});
+
+test("Test getArity with parentheses default value", () => {
+  const airty = getArity(function(a, b = 2 && (3 || 4)) {});
+  expect(arity).toBe(2);
+});
+
+test("Test getArity with native functions", () => {
+  const airty = getArity(Math.pow);
+  expect(arity).toBe(2);
 });

--- a/packages/internals/tests/functions.test.js
+++ b/packages/internals/tests/functions.test.js
@@ -39,26 +39,26 @@ test("Test getArity with rest operator", () => {
 });
 
 test("Test getArity with deconstructing parameters", () => {
-  const airty = getArity((a, { x, y, z }, c = [1, 2, 3]) => {});
+  const arity = getArity((a, { x, y, z }, c = [1, 2, 3]) => {});
   expect(arity).toBe(3);
 });
 
 test("Test getArity with array and object as default values", () => {
-  const airty = getArity((a, c = [1, 2, 3], i = { x, y, z }) => {});
+  const arity = getArity((a, c = [1, 2, 3], i = { x, y, z }) => {});
   expect(arity).toBe(3);
 });
 
 test("Test getArity with string and parentheses default values", () => {
-  const airty = getArity((a, c = ",", b = 2 && (3 || 4)) => {});
+  const arity = getArity((a, c = ",", b = 2 && (3 || 4)) => {});
   expect(arity).toBe(3);
 });
 
 test("Test getArity with parentheses default value", () => {
-  const airty = getArity(function(a, b = 2 && (3 || 4)) {});
+  const arity = getArity(function(a, b = 2 && (3 || 4)) {});
   expect(arity).toBe(2);
 });
 
 test("Test getArity with native functions", () => {
-  const airty = getArity(Math.pow);
+  const arity = getArity(Math.pow);
   expect(arity).toBe(2);
 });


### PR DESCRIPTION
Remove acorn

### Description

`acorn` is 40x bigger than the entire internals, there's no reason we need it.

### Changes proposed in this pull request

- remove `acorn`
- write a `getArity` function

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [ ] Proposed feature/fix is sufficiently documented
