### PR TITLE
Fix array.map issue

### DIFF
--- a/packages/internals/src/array.js
+++ b/packages/internals/src/array.js
@@ -5,14 +5,15 @@ class Array {
   valueOf() {
     return this.items.map(item => item.valueOf());
   }
-  map(...args) {
-    const items = this.items
-      .map(...args)
-      .map(item => (item instanceof IO ? item.valueOf() : item));
-    return new Array(...items);
+  map(fn) {
+    return this.lazyMap(fn).toArray();
   }
   lazyMap(fn) {
-    return new LazyMap({ getter: this.get, length: this.length, fn });
+    return new LazyMap({
+      getter: i => this.get(i),
+      length: this.length,
+      fn
+    });
   }
   get(index) {
     return this.items[index];

--- a/packages/internals/src/array.js
+++ b/packages/internals/src/array.js
@@ -70,6 +70,5 @@ class Array {
 
 module.exports.Array = Array;
 
-const { IO } = require("./io");
 const { LazyMap } = require("./lazyMap");
 const { Range } = require("./range");


### PR DESCRIPTION
Fixes #171 

### Description

Fixes `.map` method of arrays

### Changes proposed in this pull request

- `get` method passed to `lazyMap` as `getter` was losing its _this_ context, this is fixed now.

### ToDo

- [ ] Proposed feature/fix is sufficiently tested
- [ ] Proposed feature/fix is sufficiently documented
