### PR TITLE
Fix slices

### DIFF
--- a/packages/core/clio.beef
+++ b/packages/core/clio.beef
@@ -46,8 +46,8 @@ symbolAs symbol => asExpr { src: left.src, dest: right.raw }
 
 // - Slice
 
-slicables slicer => sliceStart { slicee: left, index: left.index }
-sliceStart array|range|slice => slice { slicee: left.slicee, slicer: right, index: left.index }
+slicer array|range => sliceDef { slicer: right, index: left.index }
+slicables sliceDef => slice { slicee: left, slicer: right.slicer, index: left.index }
 
 // - Imports
 


### PR DESCRIPTION
Fixes slicing

### Description

Gives more priority to slices, parses them from right to left now.

### Changes proposed in this pull request

- Rewrite slicing rules

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
