### PR TITLE
Clio deps cleanup

### DIFF
--- a/packages/manifest/config.js
+++ b/packages/manifest/config.js
@@ -4,5 +4,6 @@ module.exports = {
   SOURCE_NAME: "src",
   GITHUB_PREFIX: "github",
   REGISTRY_NAME: "hub",
-  URL_PREFIX: "url"
+  URL_PREFIX: "url",
+  NPM_PREFIX: "npm"
 };

--- a/packages/manifest/dependencies.js
+++ b/packages/manifest/dependencies.js
@@ -20,8 +20,14 @@ const { isClioSource, parsePackageId } = require("./utils/parse");
   { name: 'github:clio-lang/rethinkdb', version: 'latest' }
 ]
  */
-function getPackageDependencies() {
-  const config = getPackageConfig();
+function getPackageDependencies(manifestFilePath) {
+  let config;
+
+  if (manifestFilePath) {
+    config = getPackageConfig(manifestFilePath);
+  } else {
+    config = getPackageConfig();
+  }
   return config.dependencies;
 }
 
@@ -30,8 +36,14 @@ function getPackageDependencies() {
  * config file.
  * @returns {bool}
  */
-function hasClioDependencies() {
-  const dependencies = getPackageDependencies();
+function hasClioDependencies(manifestFilePath) {
+  let dependencies;
+  if (manifestFilePath) {
+    dependencies = getPackageDependencies(manifestFilePath);
+  } else {
+    dependencies = getPackageDependencies();
+  }
+
   return !!dependencies && !!Object.keys(dependencies).length;
 }
 

--- a/packages/manifest/dependencies.js
+++ b/packages/manifest/dependencies.js
@@ -78,8 +78,7 @@ function fetchDependencies() {
 /**
  * Install a Clio dependency
  *
- * @param {object} argv
- * @param {string} argv.source - url, uri or id (name[@version]) of the package to fetch
+ * @param {string} id id of the dependency, including its prefix
  * @returns {promise}
  */
 function installDependency(id) {

--- a/packages/manifest/dependencies.js
+++ b/packages/manifest/dependencies.js
@@ -96,8 +96,32 @@ function fetchDependencies() {
  * @returns {promise}
  */
 function installDependency(id) {
-  const { url, branch, githubURI, source, version, name } = parsePackageId(id);
+  const {
+    url,
+    branch,
+    githubURI,
+    source,
+    version,
+    name,
+    registry
+  } = parsePackageId(id);
 
+  let fetch;
+  try {
+    fetch = require(`./dependencies/loaders/${registry}Loader`).fetch;
+  } catch {
+    console.warn(
+      `Cannot locate a loader for registry named "${registry}", using legacy approach`
+    );
+  }
+
+  return fetch({ name, version: version || "latest" }).then(successful => {
+    if (successful && !hasClioDependency([source, "latest"])) {
+      addDependency([source, "latest"]);
+    }
+  });
+
+  //TODO: Remove from here
   if (url && !githubURI) {
     logFetching(url);
 

--- a/packages/manifest/dependencies.js
+++ b/packages/manifest/dependencies.js
@@ -13,6 +13,7 @@ const { isClioSource, parsePackageId } = require("./utils/parse");
 /**
  * Get a package dependencies
  * 
+ * @param {string|undefined} manifestFilePath optional path to config file
  * @returns {{name, version}}
  * @example 
 [
@@ -34,6 +35,7 @@ function getPackageDependencies(manifestFilePath) {
 /**
  * Returns true if the project has at least one dependency listed in the package
  * config file.
+ * @param {string|undefined} manifestFilePath optional path to config file
  * @returns {bool}
  */
 function hasClioDependencies(manifestFilePath) {

--- a/packages/manifest/dependencies.js
+++ b/packages/manifest/dependencies.js
@@ -109,7 +109,7 @@ function installDependency(id) {
   let fetch;
   try {
     fetch = require(`./dependencies/loaders/${registry}Loader`).fetch;
-  } catch {
+  } catch (_) {
     console.warn(
       `Cannot locate a loader for registry named "${registry}", using legacy approach`
     );

--- a/packages/manifest/dependencies/loaders/exampleLoader.js
+++ b/packages/manifest/dependencies/loaders/exampleLoader.js
@@ -1,0 +1,27 @@
+exports.npm = {
+  prefix: "npm",
+  fetch: ({ name, version }, destination) => {
+    // Examples:
+    // ({ name: "express", version: "latest" })
+    // ({ name: "express", version: "1.2.3" })
+  }
+};
+
+exports.url = {
+  prefix: "url",
+  fetch: ({ name, version }, destination) => {
+    // Examples:
+    // ({ name: "https://foo.com/dependency.zip", version: undefined })
+    // ({ name: "https://foo.com/dependency.tar.gz", version: undefined })
+  }
+};
+
+exports.github = {
+  prefix: "github",
+  fetch: ({ name, version }, destination) => {
+    // Examples:
+    // ({ name: "garritfra/clio-greeter", version: "0.1.0" })
+    // ({ name: "garritfra/clio-greeter", version: "master" })
+    // ({ name: "garritfra/clio-greeter", version: undefined })
+  }
+};

--- a/packages/manifest/dependencies/loaders/npmLoader.js
+++ b/packages/manifest/dependencies/loaders/npmLoader.js
@@ -1,0 +1,7 @@
+module.exports = {
+  prefix: "npm",
+  fetch: ({ name, version }, destination) => {
+    console.log("Fetching", name);
+    return Promise.resolve(true);
+  }
+};

--- a/packages/manifest/tests/parse.test.js
+++ b/packages/manifest/tests/parse.test.js
@@ -231,7 +231,8 @@ describe("pkgr/utils/parse", () => {
         isVersioned: false,
         name: githubPath,
         source: `${GITHUB_PREFIX}:${githubPath}`,
-        version: "latest"
+        version: "latest",
+        registry: GITHUB_PREFIX
       });
     });
     test("github uri (version)", () => {
@@ -243,7 +244,8 @@ describe("pkgr/utils/parse", () => {
         isVersioned: true,
         name: githubPath,
         source: `${GITHUB_PREFIX}:${githubPath}`,
-        version
+        version,
+        registry: GITHUB_PREFIX
       });
     });
     test("github uri (branch)", () => {
@@ -255,7 +257,8 @@ describe("pkgr/utils/parse", () => {
         isVersioned: false,
         name: githubPath,
         source: `${GITHUB_PREFIX}:${githubPath}`,
-        version: "latest"
+        version: "latest",
+        registry: GITHUB_PREFIX
       });
     });
 
@@ -268,7 +271,8 @@ describe("pkgr/utils/parse", () => {
         isVersioned: false,
         name: githubPath,
         source: `${GITHUB_PREFIX}:${githubPath}`,
-        version: "latest"
+        version: "latest",
+        registry: GITHUB_PREFIX
       });
     });
     test("github path (version)", () => {
@@ -280,7 +284,8 @@ describe("pkgr/utils/parse", () => {
         isVersioned: true,
         name: githubPath,
         source: `${GITHUB_PREFIX}:${githubPath}`,
-        version
+        version,
+        registry: GITHUB_PREFIX
       });
     });
 
@@ -294,7 +299,8 @@ describe("pkgr/utils/parse", () => {
         name: githubPath,
         source: `${GITHUB_PREFIX}:${githubPath}`,
         url: githubZip_branch,
-        version: "latest"
+        version: "latest",
+        registry: GITHUB_PREFIX
       });
     });
     test("github zip (version)", () => {
@@ -307,7 +313,8 @@ describe("pkgr/utils/parse", () => {
         name: githubPath,
         source: `${GITHUB_PREFIX}:${githubPath}`,
         url: githubZip_version,
-        version
+        version,
+        registry: GITHUB_PREFIX
       });
     });
 
@@ -318,7 +325,8 @@ describe("pkgr/utils/parse", () => {
         isVersioned: false,
         name,
         source: `${REGISTRY_NAME}:${name}`,
-        version: "latest"
+        version: "latest",
+        registry: REGISTRY_NAME
       });
     });
     test("name (version)", () => {
@@ -328,7 +336,8 @@ describe("pkgr/utils/parse", () => {
         isVersioned: true,
         name,
         source: `${REGISTRY_NAME}:${name}`,
-        version
+        version,
+        registry: REGISTRY_NAME
       });
     });
     test("name (branch)", () => {
@@ -338,7 +347,8 @@ describe("pkgr/utils/parse", () => {
         isVersioned: false,
         name,
         source: `${REGISTRY_NAME}:${name}`,
-        version: "latest"
+        version: "latest",
+        registry: REGISTRY_NAME
       });
     });
 
@@ -346,6 +356,7 @@ describe("pkgr/utils/parse", () => {
       const input = "http://myurl.com/path/to/dist.zip";
       expect(parsePackageId(input)).toStrictEqual({
         input,
+        registry: "url",
         url: input,
         source: `url:${input}`
       });

--- a/packages/manifest/tests/parse.test.js
+++ b/packages/manifest/tests/parse.test.js
@@ -1,4 +1,5 @@
-const { GITHUB_PREFIX, REGISTRY_NAME, URL_PREFIX } = require("../config");
+/* eslint-disable camelcase */
+const { GITHUB_PREFIX, REGISTRY_NAME } = require("../config");
 const {
   GITHUB_PATH_RE,
   GITHUB_URI_RE,

--- a/packages/manifest/utils/parse.js
+++ b/packages/manifest/utils/parse.js
@@ -1,6 +1,6 @@
 const { GITHUB_PREFIX, REGISTRY_NAME, URL_PREFIX } = require("../config");
 
-// see https://github.com/clio-lang/clio-docs/tree/dev/dev/dependency_parser
+// see https://docs.clio-lang.org/v/develop/development/dependency_parser
 const GITHUB_ZIP_RE = /(github\.com\/((?:(?:\w|\d|_|-)+\/(?:\w|\d|_|-)+){1}))\/archive\/(?:v((?:\d\.?){1,3})|((?:\w|\d|_|-)+))(?:\.zip)$/i;
 const GITHUB_URI_RE = /(github\.com\/((?:(?:\w|\d|_|-)+\/(?:\w|\d|_|-)+){1}))(?:@(?:((?:\d\.?){1,3})|((?:\w|\d|_|-)+)))?$/i;
 const GITHUB_PATH_RE = /^((?:(?:\w|\d|_|-)+\/(?:\w|\d|_|-)+){1})(?:@(?:((?:\d\.?){1,3})|((?:\w|\d|_|-)+)))?$/i;

--- a/packages/manifest/utils/parse.js
+++ b/packages/manifest/utils/parse.js
@@ -8,7 +8,7 @@ const NAME_RE = /^((?:\w|\d|_|-)+)(?:@(?:((?:\d\.?){1,3})|((?:\w|\d|_|-)+)))?$/i
 const URL_RE = /https?:\/\/.+/gi;
 
 const prefixes = `${GITHUB_PREFIX}|${REGISTRY_NAME}|${URL_PREFIX}`;
-const prefix_re = new RegExp(`(${prefixes}):(.+)`, "i");
+const prefixRegex = new RegExp(`(${prefixes}):(.+)`, "i");
 
 /**
  * Returns an object whose properties represent significant elements
@@ -23,7 +23,7 @@ const parsePackageId = input => {
   let parsed = { input };
   let id = input;
 
-  const prefixExec = prefix_re.exec(input);
+  const prefixExec = prefixRegex.exec(input);
   if (prefixExec) {
     id = prefixExec[2];
   }
@@ -105,7 +105,7 @@ isClioSource('github:foo/bar') // true
 isClioSource('hub:stdlib') // true
 isClioSource('stdlib') // false
  */
-const isClioSource = input => prefix_re.exec(input) !== null;
+const isClioSource = input => prefixRegex.exec(input) !== null;
 
 module.exports = {
   GITHUB_PATH_RE,

--- a/packages/manifest/utils/parse.js
+++ b/packages/manifest/utils/parse.js
@@ -1,4 +1,9 @@
-const { GITHUB_PREFIX, REGISTRY_NAME, URL_PREFIX } = require("../config");
+const {
+  GITHUB_PREFIX,
+  REGISTRY_NAME,
+  URL_PREFIX,
+  NPM_PREFIX
+} = require("../config");
 
 // see https://docs.clio-lang.org/v/develop/development/dependency_parser
 const GITHUB_ZIP_RE = /(github\.com\/((?:(?:\w|\d|_|-)+\/(?:\w|\d|_|-)+){1}))\/archive\/(?:v((?:\d\.?){1,3})|((?:\w|\d|_|-)+))(?:\.zip)$/i;
@@ -7,7 +12,7 @@ const GITHUB_PATH_RE = /^((?:(?:\w|\d|_|-)+\/(?:\w|\d|_|-)+){1})(?:@(?:((?:\d\.?
 const NAME_RE = /^((?:\w|\d|_|-)+)(?:@(?:((?:\d\.?){1,3})|((?:\w|\d|_|-)+)))?$/i;
 const URL_RE = /https?:\/\/.+/gi;
 
-const prefixes = `${GITHUB_PREFIX}|${REGISTRY_NAME}|${URL_PREFIX}`;
+const prefixes = `${GITHUB_PREFIX}|${REGISTRY_NAME}|${URL_PREFIX}|${NPM_PREFIX}`;
 const prefixRegex = new RegExp(`(${prefixes}):(.+)`, "i");
 
 /**
@@ -26,6 +31,7 @@ const parsePackageId = input => {
   const prefixExec = prefixRegex.exec(input);
   if (prefixExec) {
     id = prefixExec[2];
+    parsed.registry = prefixExec[1];
   }
 
   // also valid for url:*
@@ -45,8 +51,7 @@ const parsePackageId = input => {
         isVersioned: !!ghZipExec[3],
         name: ghZipExec[2],
         source: `${GITHUB_PREFIX}:${ghZipExec[2]}`,
-        version: ghZipExec[3] || "latest",
-        registry: "github"
+        version: ghZipExec[3] || "latest"
       };
     }
 
@@ -63,8 +68,7 @@ const parsePackageId = input => {
       isVersioned: !!ghUriExec[3],
       name: ghUriExec[2],
       source: `${GITHUB_PREFIX}:${ghUriExec[2]}`,
-      version: ghUriExec[3] || "latest",
-      registry: GITHUB_PREFIX
+      version: ghUriExec[3] || "latest"
     };
   }
 
@@ -79,8 +83,7 @@ const parsePackageId = input => {
       isVersioned: !!ghPathExec[2],
       name: ghPathExec[1],
       source: `${GITHUB_PREFIX}:${ghPathExec[1]}`,
-      version: ghPathExec[2] || "latest",
-      registry: GITHUB_PREFIX
+      version: ghPathExec[2] || "latest"
     };
   }
 
@@ -93,8 +96,7 @@ const parsePackageId = input => {
       name: nameExec[1],
       source: `${REGISTRY_NAME}:${nameExec[1]}`,
       isVersioned: !!nameExec[2],
-      version: nameExec[2] || "latest",
-      registry: "hub"
+      version: nameExec[2] || "latest"
     };
   }
 };

--- a/packages/manifest/utils/parse.js
+++ b/packages/manifest/utils/parse.js
@@ -33,6 +33,7 @@ const parsePackageId = input => {
   if (urlMatch) {
     parsed.source = `${URL_PREFIX}:${urlMatch[0]}`;
     parsed.url = urlMatch[0];
+    parsed.registry = "url";
 
     const ghZipExec = GITHUB_ZIP_RE.exec(id);
     if (ghZipExec) {
@@ -44,7 +45,8 @@ const parsePackageId = input => {
         isVersioned: !!ghZipExec[3],
         name: ghZipExec[2],
         source: `${GITHUB_PREFIX}:${ghZipExec[2]}`,
-        version: ghZipExec[3] || "latest"
+        version: ghZipExec[3] || "latest",
+        registry: "github"
       };
     }
 
@@ -61,7 +63,8 @@ const parsePackageId = input => {
       isVersioned: !!ghUriExec[3],
       name: ghUriExec[2],
       source: `${GITHUB_PREFIX}:${ghUriExec[2]}`,
-      version: ghUriExec[3] || "latest"
+      version: ghUriExec[3] || "latest",
+      registry: GITHUB_PREFIX
     };
   }
 
@@ -76,7 +79,8 @@ const parsePackageId = input => {
       isVersioned: !!ghPathExec[2],
       name: ghPathExec[1],
       source: `${GITHUB_PREFIX}:${ghPathExec[1]}`,
-      version: ghPathExec[2] || "latest"
+      version: ghPathExec[2] || "latest",
+      registry: GITHUB_PREFIX
     };
   }
 
@@ -89,7 +93,8 @@ const parsePackageId = input => {
       name: nameExec[1],
       source: `${REGISTRY_NAME}:${nameExec[1]}`,
       isVersioned: !!nameExec[2],
-      version: nameExec[2] || "latest"
+      version: nameExec[2] || "latest",
+      registry: "hub"
     };
   }
 };


### PR DESCRIPTION
Fixes `null`
### Description

The cli-wise dependency management is a little bit messy. @mindrones did a great job implementing a system for dependencies. This PR aims to implement this system into the CLI and manifest.

### Changes proposed in this pull request

- ...

### ToDo

- [ ] Paths can be specified in manifest
- [ ] Arbitrary deps can be added through CLI
- [ ] GitHub deps can be added with ID `github:garritfra/clio-greeter`

- [ ] Proposed feature/fix is sufficiently tested
- [ ] Proposed feature/fix is sufficiently documented
  - [ ] Loaders are documented
