### PR TITLE
Fix crashing test

### DIFF
--- a/packages/cli/commands/tests/build.test.js
+++ b/packages/cli/commands/tests/build.test.js
@@ -11,6 +11,8 @@ const {
 
 jest.mock("clio-manifest/npm_dependencies");
 
+process.exit = jest.fn();
+
 describe("Package.json generation", () => {
   test("Build generates package.json", async () => {
     const dir = tmp.dirSync();


### PR DESCRIPTION
### Description

I noticed that theres a failing test that somehow cannot be traced. The cause is the `process.exit` function, which just crashes the test and tries again. I have stubbed this function, which should fix the tests

### Changes proposed in this pull request

- Stub `process.exit`

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
