### PR TITLE
Fix link to introduction article

### DIFF
--- a/packages/website/src/App.svelte
+++ b/packages/website/src/App.svelte
@@ -223,7 +223,7 @@
     </p>
     <p>
       Read the
-      <a href="https://medium.com">introduction article</a>
+      <a href="https://blog.usejournal.com/introduction-to-clio-40dbbf9c250b">introduction article</a>
       on our blog to learn more.
     </p>
   </div>


### PR DESCRIPTION
This was just pointing at medium.com, use the actual article link :)

Fixes #194.