### PR TITLE
Some links and typos

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,5 +10,5 @@ Use Clio's integrated CLI to bootstrap a new project. To do so, run:
 clio new hello
 ```
 
-Change into the directory using `cd hello` and run the automatically generated `index.clio` file with `clio run`. How does Clio know which file to run? Take a look at `clio.toml`. The field `main` specifies the entry point of your application. You can also specify other fields such as information about the author, the version of the project and much more. To list all available commands of Clio, simply run `clio` in your shell.
+Change into the directory using `cd hello` and run the automatically generated `main.clio` file with `clio run`. How does Clio know which file to run? Take a look at `clio.toml`. The field `main` specifies the entry point of your application. You can also specify other fields such as information about the author, the version of the project and much more. To list all available commands of Clio, simply run `clio` in your shell.
 

--- a/docs/learn/official-tutorial/calls.md
+++ b/docs/learn/official-tutorial/calls.md
@@ -7,7 +7,7 @@ fn add a b:
   a + b
 ```
 
-We can run call this function in two different ways. You saw the first form in the Hello World! section:
+We can call this function in two different ways. You saw the first form in the Hello World! section:
 
 ```text
 export fn main argv:

--- a/docs/learn/official-tutorial/introduction.md
+++ b/docs/learn/official-tutorial/introduction.md
@@ -12,5 +12,5 @@ Clio allows to easily chain functions together with flexibility without losing r
 
 All functions have a parallel version in Clio, they're isolated but not free of side-effects, Clio provides tools to host these functions, export them, import and work with them in any other place in any language. With the network-based foreign function interface you'll be able to use most of the modules of any other programming language with ease.
 
-This document assumes you have at least a basic programming knowledge and you're familiar with concepts like a variable or a function, but it should also be easy for non-programmers to pick up.This article also assumes you have installed Clio and you have a working Clio installation. If not, please follow the install instructions [here](../../install.md). If you're not ready yet to install Clio, you can always use our playground.
+This document assumes you have at least a basic programming knowledge and you're familiar with concepts like a variable or a function, but it should also be easy for non-programmers to pick up.This article also assumes you have installed Clio and you have a working Clio installation. If not, please follow the install instructions [here](../../install.md). If you're not ready yet to install Clio, you can always use our [playground](https://playground.clio-lang.org/).
 

--- a/docs/learn/official-tutorial/prepreparation.md
+++ b/docs/learn/official-tutorial/prepreparation.md
@@ -8,5 +8,5 @@ clio new tutorial
 
 Then `cd` into the new directory \(`tutorial`, if you ran the above command as is, otherwise the name you chose for your project\), and continue with this guide.
 
-Please note you can also use the Clio playground to test out the code samples.
+Please note you can also use the [Clio playground](https://playground.clio-lang.org/) to test out the code samples.
 

--- a/packages/website/src/components/Hero.svelte
+++ b/packages/website/src/components/Hero.svelte
@@ -16,7 +16,9 @@
 
     <div class="learn-more">
       Visit our
-      <a href="https://docs.clio-lang.org/tutorial">tutorial page</a>
+      <a href="https://docs.clio-lang.org/learn/official-tutorial"
+        >tutorial page</a
+      >
       to learn Clio, or read the
       <a href="https://docs.clio-lang.org">documentation</a>
       to learn more.


### PR DESCRIPTION
### Description
1) frontpage: tutorial link not found, should be: https://docs.clio-lang.org/learn/official-tutorial

2) https://docs.clio-lang.org/getting-started
	and run the automatically generated index.clio file with clio run  index.clio ??

3) https://docs.clio-lang.org/learn/official-tutorial/introduction 
playground: make link
idem on: https://docs.clio-lang.org/learn/official-tutorial/prepreparation

4) https://docs.clio-lang.org/learn/official-tutorial/calls
run call <-- call